### PR TITLE
Update Monster Names

### DIFF
--- a/src/app/models/entity.model.ts
+++ b/src/app/models/entity.model.ts
@@ -223,7 +223,7 @@ export class Monster extends Entity {
   ];
 
   private static species = [
-    "Warg", "Spider", "Lich", "Bandit", "Wolf", "Golem", "Beast", "Wraith", "Bat", "Cultist", "Serpent", "Ghoul"
+    "Demon Warg", "Demon Spider", "Demon Lich", "Demon Bandit", "Demon Wolf", "Demon Golem", "Demon Beast", "Demon Wraith", "Demon Bat", "Demon Cultist", "Demon Serpent", "Demon Ghoul"
   ];
 
   get totalArmor(): number {
@@ -338,4 +338,3 @@ export const MONSTER_AFFIX_BONUSES: Record<string, MonsterBonus> = {
   "of Stone":        { stat: "Armor", flat: 3, percent: 0.01 },
   "of Fortitude":    { stat: "Armor", flat: 6, percent: 0.02 }
 };
-


### PR DESCRIPTION
Updated the names of monster species to reflect demon imagery as previously discussed. This change includes modifying the existing names to their new demon-themed counterparts.